### PR TITLE
Upgradle to 8.6 and upgrade versions

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPluginTest.kt
+++ b/src/test/kotlin/org/gradle/kotlin/dsl/experiments/plugins/GradleKotlinDslKtlintConventionPluginTest.kt
@@ -39,7 +39,7 @@ class GradleKotlinDslKtlintConventionPluginTest {
             }
 
             repositories {
-                jcenter()
+                mavenCentral()
             }
             """
         )


### PR DESCRIPTION
This upgrades Gradle, and the publishing plugin version.

I didn't manage to upgrade ktlint, [here](https://ge.gradle.org/s/rtli5vp6ak37q/tests/overview?outcome=FAILED) are the test failures.